### PR TITLE
Fix bot authorization flow for new twitch apps

### DIFF
--- a/migrations/000006_create_bot_table.up.sql
+++ b/migrations/000006_create_bot_table.up.sql
@@ -5,7 +5,7 @@ CREATE TABLE `pb_bot` (
 	`twitch_refresh_token` VARCHAR(64) NULL DEFAULT NULL COMMENT 'Bot level refresh-token',
 	PRIMARY KEY (`id`)
 )
-COMMENT='Store available bot accouns, requires an access token with chat_login scope'
+COMMENT='Store available bot accouns, requires an access token with all chat/PubSub scopes'
 COLLATE='utf8mb4_general_ci'
 ENGINE=InnoDB
 ;

--- a/migrations/000006_create_bot_table.up.sql
+++ b/migrations/000006_create_bot_table.up.sql
@@ -5,7 +5,7 @@ CREATE TABLE `pb_bot` (
 	`twitch_refresh_token` VARCHAR(64) NULL DEFAULT NULL COMMENT 'Bot level refresh-token',
 	PRIMARY KEY (`id`)
 )
-COMMENT='Store available bot accouns, requires an access token with all chat/PubSub scopes'
+COMMENT='Store available bot accouns, requires an access token with chat_login scope'
 COLLATE='utf8mb4_general_ci'
 ENGINE=InnoDB
 ;

--- a/web/controller/api/auth/twitch/twitch.go
+++ b/web/controller/api/auth/twitch/twitch.go
@@ -187,9 +187,14 @@ func Load(parent *mux.Router, appConfig *config.AuthTwitchConfig) error {
 	twitchBotOauth.RedirectURL = appConfig.Bot.RedirectURI
 	twitchBotOauth.ClientID = appConfig.Bot.ClientID
 	twitchBotOauth.ClientSecret = appConfig.Bot.ClientSecret
+	// https://dev.twitch.tv/docs/authentication/#scopes
 	twitchBotOauth.Scopes = []string{
 		"user_read",
-		"chat_login",
+		"channel:moderate",
+		"chat:edit",
+		"chat:read",
+		"whispers:read",
+		"whispers:edit"
 	}
 	twitchBotOauth.Endpoint = oauth2.Endpoint{
 		AuthURL:  "https://id.twitch.tv/oauth2/authorize",

--- a/web/controller/api/auth/twitch/twitch.go
+++ b/web/controller/api/auth/twitch/twitch.go
@@ -194,7 +194,7 @@ func Load(parent *mux.Router, appConfig *config.AuthTwitchConfig) error {
 		"chat:edit",
 		"chat:read",
 		"whispers:read",
-		"whispers:edit"
+		"whispers:edit",
 	}
 	twitchBotOauth.Endpoint = oauth2.Endpoint{
 		AuthURL:  "https://id.twitch.tv/oauth2/authorize",


### PR DESCRIPTION
Use the new Chat/PubSub authorization scopes, replacing `chat_read`.

https://dev.twitch.tv/docs/authentication/#scopes